### PR TITLE
BAH-1807 - Resolves failing test case

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -31,6 +31,12 @@
             <artifactId>openmrs-web</artifactId>
             <version>${openmrsCoreVersion}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.openmrs.api</groupId>

--- a/omod/src/main/java/org/openmrs/module/idgen/webservices/controller/IdgenIdentifierTypeController.java
+++ b/omod/src/main/java/org/openmrs/module/idgen/webservices/controller/IdgenIdentifierTypeController.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.idgen.webservices.controller;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import org.openmrs.api.context.Context;
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/" + IdgenWsConstants.PATH_IDGEN_IDTYPE)
 public class IdgenIdentifierTypeController {
 	
-	public final static String encoding = StandardCharsets.UTF_8.toString();
-	
+	public final static String encoding = Charset.forName("UTF-8").toString();
+
 	public final static String contentType = "application/json;charset=" + encoding;
 	
 	@Autowired

--- a/omod/src/test/java/org/openmrs/module/idgen/webservices/controller/IdgenIdentifierTypeResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/idgen/webservices/controller/IdgenIdentifierTypeResourceTest.java
@@ -18,17 +18,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
-import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 public class IdgenIdentifierTypeResourceTest extends BaseModuleWebContextSensitiveTest {
 	
 	@Autowired
-	private AnnotationMethodHandlerAdapter handlerAdapter;
+	private RequestMappingHandlerAdapter handlerAdapter;
 	
 	@Autowired
-	@Qualifier("org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping#0")
-	private DefaultAnnotationHandlerMapping handlerMapping;
+	@Qualifier("org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping#0")
+	private RequestMappingHandlerMapping handlerMapping;
 	
 	@Before
 	public void setup() {

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
     </modules>
     
     <properties>
-        <openmrsCoreVersion>2.0.0</openmrsCoreVersion>
-        <webservicesRestModuleVersion>2.6</webservicesRestModuleVersion>
-        <idGenVersion>4.4.1</idGenVersion>
+        <openmrsCoreVersion>2.4.2</openmrsCoreVersion>
+        <webservicesRestModuleVersion>2.29.0</webservicesRestModuleVersion>
+        <idGenVersion>4.7.0</idGenVersion>
+        <javaxServletApiVersion>4.0.1</javaxServletApiVersion>
     </properties>
     
     <scm>
@@ -36,13 +37,19 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>[1.2,1.5]</version>
+            <version>1.9.14-MULE-002</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javaxServletApiVersion}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>[1.2,1.5]</version>
+            <version>1.9.14-MULE-002</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -51,7 +58,7 @@
         <repository>
             <id>openmrs-repo</id>
             <name>OpenMRS Nexus Repository</name>
-            <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+            <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
         </repository>
     </repositories>
     
@@ -113,7 +120,7 @@
         <pluginRepository>
             <id>openmrs-repo</id>
             <name>OpenMRS Nexus Repository</name>
-            <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+            <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
This PR is about:
- Resolving failing test case
- Upgrades openmrs-Version to 2.4.2, webservices-rest version to 2.29.0, id-gen version to 4.7.0, javax-servlet-api version to 4.0.1
- Upgrades jackson-* dependencies to 1.9.14-MULE-002 to resolve vulnerability